### PR TITLE
Fix compiler crash with value class in result position

### DIFF
--- a/src/main/scala/scala/async/internal/TransformUtils.scala
+++ b/src/main/scala/scala/async/internal/TransformUtils.scala
@@ -343,9 +343,8 @@ private[async] trait TransformUtils {
         New(TypeTree(baseType)))), tpSym.asClass.primaryConstructor)
 
       val zero = gen.mkMethodCall(target, argZero :: Nil)
-
       // restore the original type which we might otherwise have weakened with `baseType` above
-      gen.mkCast(zero, tp)
+      c.typecheck(atMacroPos(gen.mkCast(zero, tp)))
     } else {
       gen.mkZero(tp)
     }

--- a/src/test/scala/scala/async/run/toughtype/ToughType.scala
+++ b/src/test/scala/scala/async/run/toughtype/ToughType.scala
@@ -319,6 +319,19 @@ class ToughTypeSpec {
     val result = Await.result(fut, 5.seconds)
     result mustEqual 1
   }
+
+  // https://github.com/scala/async/issues/106
+  @Test def valueClassT106(): Unit = {
+    import scala.async.internal.AsyncId._
+    async {
+      "whatever value" match {
+        case _ =>
+          await("whatever return type")
+          new IntWrapper("value class matters")
+      }
+      "whatever return type"
+    }
+  }
 }
 
 class IntWrapper(val value: String) extends AnyVal {


### PR DESCRIPTION
We were leaking untyped trees out of the macro, which crashed
in refchecks.

This commit proactively typechecks the tree returned by `mkZero`.