### PR TITLE
Fix compiler crash with value class in result position

### DIFF
--- a/src/main/scala/scala/async/internal/TransformUtils.scala
+++ b/src/main/scala/scala/async/internal/TransformUtils.scala
@@ -259,10 +259,11 @@ private[async] trait TransformUtils {
     if (tp.typeSymbol.isDerivedValueClass) {
       val argZero = mkZero(tp.memberType(tp.typeSymbol.derivedValueClassUnbox).resultType)
       val target: Tree = gen.mkAttributedSelect(
-        typer.typedPos(macroPos)(
+        callSiteTyper.typedPos(macroPos)(
         New(TypeTree(tp.baseType(tp.typeSymbol)))), tp.typeSymbol.primaryConstructor)
       val zero = gen.mkMethodCall(target, argZero :: Nil)
-      gen.mkCast(zero, tp)
+      // restore the original type which we might otherwise have weakened with `baseType` above
+      callSiteTyper.typedPos(macroPos)(gen.mkCast(zero, tp))
     } else {
       gen.mkZero(tp)
     }

--- a/src/test/scala/scala/async/run/toughtype/ToughType.scala
+++ b/src/test/scala/scala/async/run/toughtype/ToughType.scala
@@ -286,6 +286,19 @@ class ToughTypeSpec {
     val result = Await.result(fut, 5.seconds)
     result mustBe None
   }
+
+  // https://github.com/scala/async/issues/106
+  @Test def valueClassT106(): Unit = {
+    import scala.async.internal.AsyncId._
+    async {
+      "whatever value" match {
+        case _ =>
+          await("whatever return type")
+          new IntWrapper("value class matters")
+      }
+      "whatever return type"
+    }
+  }
 }
 
 class IntWrapper(val value: String) extends AnyVal {


### PR DESCRIPTION
We were leaking untyped trees out of the macro, which crashed
in refchecks.

This commit proactively typechecks the tree returned by `mkZero`.

(cherry picked from commit f4275e22e000541eb619808723b70bd64b9b4873)