### PR TITLE
Avoid masking real errors with NotImplemented awaiting Future[Nothing]

### DIFF
--- a/src/main/scala/scala/async/internal/LiveVariables.scala
+++ b/src/main/scala/scala/async/internal/LiveVariables.scala
@@ -56,7 +56,7 @@ trait LiveVariables {
     // determine which fields should be live also at the end (will not be nulled out)
     val noNull: Set[Symbol] = liftedSyms.filter { sym =>
       val typeSym = tpe(sym).typeSymbol
-      (typeSym.isClass && typeSym.asClass.isPrimitive) || liftables.exists { tree =>
+      (typeSym.isClass && (typeSym.asClass.isPrimitive || typeSym == definitions.NothingClass)) || liftables.exists { tree =>
         !liftedSyms.contains(tree.symbol) && tree.exists(_.symbol == sym)
       }
     }


### PR DESCRIPTION
This commit disabled live variable analysis for intermediate values of type Nothing.

Fixes #104