### PR TITLE
[backport] Avoid masking real errors with NotImplemented awaiting Future[Nothing]

### DIFF
--- a/src/main/scala/scala/async/internal/LiveVariables.scala
+++ b/src/main/scala/scala/async/internal/LiveVariables.scala
@@ -56,7 +56,7 @@ trait LiveVariables {
 
     // determine which fields should be live also at the end (will not be nulled out)
     val noNull: Set[Symbol] = liftedSyms.filter { sym =>
-      sym.tpe.typeSymbol.isPrimitiveValueClass || liftables.exists { tree =>
+      sym.tpe.typeSymbol.isPrimitiveValueClass || sym.tpe.typeSymbol == definitions.NothingClass || liftables.exists { tree =>
         !liftedSyms.contains(tree.symbol) && tree.exists(_.symbol == sym)
       }
     }


### PR DESCRIPTION
This commit disabled live variable analysis for intermediate values of type Nothing.

Fixes #104

(cherry picked from commit 6353443a0adec384172c38efac3bc96b9d2cbad2)