### PR TITLE
Avoid compiler warning when awaiting Future[Unit]

### DIFF
--- a/src/main/scala/scala/async/internal/AnfTransform.scala
+++ b/src/main/scala/scala/async/internal/AnfTransform.scala
@@ -51,7 +51,17 @@ private[async] trait AnfTransform {
           expr match {
             case Apply(fun, args) if isAwait(fun) =>
               val valDef = defineVal(name.await, expr, tree.pos)
-              stats :+ valDef :+ atPos(tree.pos)(gen.mkAttributedStableRef(valDef.symbol)).setType(tree.tpe)
+              val ref = gen.mkAttributedStableRef(valDef.symbol).setType(tree.tpe)
+              val ref1 = if (ref.tpe =:= definitions.UnitTpe)
+                // https://github.com/scala/async/issues/74
+                // Use a cast to hide from "pure expression does nothing" error
+                //
+                // TODO avoid creating a ValDef for the result of this await to avoid this tree shape altogether.
+                // This will require some deeper changes to the later parts of the macro which currently assume regular
+                // tree structure around `await` calls.
+                gen.mkCast(ref, definitions.UnitTpe)
+              else ref
+              stats :+ valDef :+ atPos(tree.pos)(ref1)
 
             case If(cond, thenp, elsep) =>
               // if type of if-else is Unit don't introduce assignment,

--- a/src/test/scala/scala/async/run/WarningsSpec.scala
+++ b/src/test/scala/scala/async/run/WarningsSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2012-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package scala.async
+package run
+
+import org.junit.Test
+
+import scala.async.internal.AsyncId
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.{postfixOps, reflectiveCalls}
+
+
+class WarningsSpec {
+
+  @Test
+  // https://github.com/scala/async/issues/74
+  def noPureExpressionInStatementPositionWarning_t74() {
+    val tb = mkToolbox(s"-cp ${toolboxClasspath} -Xfatal-warnings")
+    // was: "a pure expression does nothing in statement position; you may be omitting necessary parentheses"
+    tb.eval(tb.parse {
+      """
+        |  import scala.async.internal.AsyncId._
+        |   async {
+        |     if ("".isEmpty) {
+        |       await(println("hello"))
+        |       ()
+        |     } else 42
+        |   }
+      """.stripMargin
+    })
+  }
+}


### PR DESCRIPTION
During the ANF transform, we were generating a tree of the shape:

   {
     val temp: Unit = await(futureOfUnit)
     temp
     ()
   }

I tried to simplifiy this to avoid creating the temporary value,
but this proved difficult as it would have required changes to
the subsequent state machine transformation.

Even replacing `temp` with `()` made the state machine transform
harder.

So for now, I've just inserted `temp.asInstanceOf[Unit]` to hide
from the compiler warning.

Fixes #74