### PR TITLE
Avoid compiler warning when awaiting Future[Unit]

### DIFF
--- a/src/test/scala/scala/async/run/WarningsSpec.scala
+++ b/src/test/scala/scala/async/run/WarningsSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2012-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package scala.async
+package run
+
+import org.junit.Test
+
+import scala.async.internal.AsyncId
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.{postfixOps, reflectiveCalls}
+
+
+class WarningsSpec {
+
+  @Test
+  // https://github.com/scala/async/issues/74
+  def noPureExpressionInStatementPositionWarning_t74() {
+    val tb = mkToolbox(s"-cp ${toolboxClasspath} -Xfatal-warnings")
+    // was: "a pure expression does nothing in statement position; you may be omitting necessary parentheses"
+    tb.eval(tb.parse {
+      """
+        |  import scala.async.internal.AsyncId._
+        |   async {
+        |     if ("".isEmpty) {
+        |       await(println("hello"))
+        |       ()
+        |     } else 42
+        |   }
+      """.stripMargin
+    })
+  }
+}


### PR DESCRIPTION
During the ANF transform, we were generating a tree of the shape:

```
   {
     val temp: Unit = await(futureOfUnit)
     temp
     ()
   }
```

I tried to simplifiy this to avoid creating the temporary value,
but this proved difficult as it would have required changes to
the subsequent state machine transformation.

Even replacing `temp` with `()` made the state machine transform
harder.

So for now, I've just inserted `temp.asInstanceOf[Unit]` to hide
from the compiler warning.

Fixes #74

(cherry picked from commit f3f058991b207a07041672a7e119422d9054788d)