### PR TITLE
Avoid leaking untyped trees out of macro

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.8

--- a/src/main/scala/scala/async/internal/AnfTransform.scala
+++ b/src/main/scala/scala/async/internal/AnfTransform.scala
@@ -59,7 +59,7 @@ private[async] trait AnfTransform {
                 // TODO avoid creating a ValDef for the result of this await to avoid this tree shape altogether.
                 // This will require some deeper changes to the later parts of the macro which currently assume regular
                 // tree structure around `await` calls.
-                gen.mkCast(ref, definitions.UnitTpe)
+                api.typecheck(atPos(tree.pos)(gen.mkCast(ref, definitions.UnitTpe)))
               else ref
               stats :+ valDef :+ atPos(tree.pos)(ref1)
 


### PR DESCRIPTION
The stack trace and bisection in #119 made me notice that we
are failing to typecheck the cast we generated in the fix for #74.

The ticket doesn't have a reproduction, so I'm submitting this
without a test case.