### PR TITLE
Avoid masking user exception with ??? for Nothing typed expressions

### DIFF
--- a/src/main/scala/scala/async/internal/TransformUtils.scala
+++ b/src/main/scala/scala/async/internal/TransformUtils.scala
@@ -151,6 +151,7 @@ private[async] trait TransformUtils {
 
     val NonFatalClass = rootMirror.staticModule("scala.util.control.NonFatal")
     val Async_await   = asyncBase.awaitMethod(c.universe)(c.macroApplication.symbol).ensuring(_ != NoSymbol)
+    val IllegalStateExceptionClass = rootMirror.staticClass("java.lang.IllegalStateException")
   }
 
   // `while(await(x))` ... or `do { await(x); ... } while(...)` contain an `If` that loops;


### PR DESCRIPTION
Code like:

    val x = if (cond) throw new A else throw new B

Was being transformed to:

    val ifRes = ???
    if (cond) ifRes = throw new A else ifRes = throw new B
    val x = ifRes

by way of the use of `gen.mkZero` which throws `???` if the requested type is `Nothing`

This commit special cases `Nothing` typed expressions in a similar manner to `Unit` type expressions.
The example above is now translated to:

    if (cond) throw new A else throw new B
    val x = throw new IllegalStateException()

Fixed #120