### PR TITLE
Enable a compiler plugin to use the async transform after patmat

### DIFF
--- a/src/main/scala/scala/async/internal/AsyncBase.scala
+++ b/src/main/scala/scala/async/internal/AsyncBase.scala
@@ -43,9 +43,9 @@ abstract class AsyncBase {
                                  (body: c.Expr[T])
                                  (execContext: c.Expr[futureSystem.ExecContext]): c.Expr[futureSystem.Fut[T]] = {
     import c.universe._, c.internal._, decorators._
-    val asyncMacro = AsyncMacro(c, self)
+    val asyncMacro = AsyncMacro(c, self)(body.tree)
 
-    val code = asyncMacro.asyncTransform[T](body.tree, execContext.tree)(c.weakTypeTag[T])
+    val code = asyncMacro.asyncTransform[T](execContext.tree)(c.weakTypeTag[T])
     AsyncUtils.vprintln(s"async state machine transform expands to:\n ${code}")
 
     // Mark range positions for synthetic code as transparent to allow some wiggle room for overlapping ranges

--- a/src/main/scala/scala/async/internal/AsyncId.scala
+++ b/src/main/scala/scala/async/internal/AsyncId.scala
@@ -41,11 +41,11 @@ object AsyncTestLV extends AsyncBase {
  * A trivial implementation of [[FutureSystem]] that performs computations
  * on the current thread. Useful for testing.
  */
+class Box[A] {
+  var a: A = _
+}
 object IdentityFutureSystem extends FutureSystem {
-
-  class Prom[A] {
-    var a: A = _
-  }
+  type Prom[A] = Box[A]
 
   type Fut[A] = A
   type ExecContext = Unit
@@ -57,7 +57,7 @@ object IdentityFutureSystem extends FutureSystem {
 
     def execContext: Expr[ExecContext] = c.Expr[Unit](Literal(Constant(())))
 
-    def promType[A: WeakTypeTag]: Type = weakTypeOf[Prom[A]]
+    def promType[A: WeakTypeTag]: Type = weakTypeOf[Box[A]]
     def tryType[A: WeakTypeTag]: Type = weakTypeOf[scala.util.Try[A]]
     def execContextType: Type = weakTypeOf[Unit]
 

--- a/src/main/scala/scala/async/internal/AsyncMacro.scala
+++ b/src/main/scala/scala/async/internal/AsyncMacro.scala
@@ -1,15 +1,17 @@
 package scala.async.internal
 
 object AsyncMacro {
-  def apply(c0: reflect.macros.Context, base: AsyncBase): AsyncMacro { val c: c0.type } = {
+  def apply(c0: reflect.macros.Context, base: AsyncBase)(body0: c0.Tree): AsyncMacro { val c: c0.type } = {
     import language.reflectiveCalls
     new AsyncMacro { self =>
       val c: c0.type                                             = c0
+      val body: c.Tree = body0
       // This member is required by `AsyncTransform`:
       val asyncBase: AsyncBase                                   = base
       // These members are required by `ExprBuilder`:
       val futureSystem: FutureSystem                             = base.futureSystem
       val futureSystemOps: futureSystem.Ops {val c: self.c.type} = futureSystem.mkOps(c)
+      val containsAwait: c.Tree => Boolean = containsAwaitCached(body0)
     }
   }
 }
@@ -19,7 +21,10 @@ private[async] trait AsyncMacro
   with ExprBuilder with AsyncTransform with AsyncAnalysis with LiveVariables {
 
   val c: scala.reflect.macros.Context
+  val body: c.Tree
+  val containsAwait: c.Tree => Boolean
 
   lazy val macroPos = c.macroApplication.pos.makeTransparent
   def atMacroPos(t: c.Tree) = c.universe.atPos(macroPos)(t)
+
 }

--- a/src/main/scala/scala/async/internal/AsyncTransform.scala
+++ b/src/main/scala/scala/async/internal/AsyncTransform.scala
@@ -98,10 +98,11 @@ trait AsyncTransform {
     }
 
     val isSimple = asyncBlock.asyncStates.size == 1
-    if (isSimple)
+    val result = if (isSimple)
       futureSystemOps.spawn(body, execContext) // generate lean code for the simple case of `async { 1 + 1 }`
     else
       startStateMachine
+    cleanupContainsAwaitAttachments(result)
   }
 
   def logDiagnostics(anfTree: Tree, states: Seq[String]) {

--- a/src/main/scala/scala/async/internal/AsyncTransform.scala
+++ b/src/main/scala/scala/async/internal/AsyncTransform.scala
@@ -9,7 +9,7 @@ trait AsyncTransform {
 
   val asyncBase: AsyncBase
 
-  def asyncTransform[T](body: Tree, execContext: Tree)
+  def asyncTransform[T](execContext: Tree)
                        (resultType: WeakTypeTag[T]): Tree = {
 
     // We annotate the type of the whole expression as `T @uncheckedBounds` so as not to introduce
@@ -22,7 +22,7 @@ trait AsyncTransform {
     // Transform to A-normal form:
     //  - no await calls in qualifiers or arguments,
     //  - if/match only used in statement position.
-    val anfTree0: Block = anfTransform(body)
+    val anfTree0: Block = anfTransform(body, c.internal.enclosingOwner)
 
     val anfTree = futureSystemOps.postAnfTransform(anfTree0)
 
@@ -35,7 +35,7 @@ trait AsyncTransform {
     val stateMachine: ClassDef = {
       val body: List[Tree] = {
         val stateVar = ValDef(Modifiers(Flag.MUTABLE | Flag.PRIVATE | Flag.LOCAL), name.state, TypeTree(definitions.IntTpe), Literal(Constant(StateAssigner.Initial)))
-        val result = ValDef(NoMods, name.result, TypeTree(futureSystemOps.promType[T](uncheckedBoundsResultTag)), futureSystemOps.createProm[T](uncheckedBoundsResultTag).tree)
+        val resultAndAccessors = mkMutableField(futureSystemOps.promType[T](uncheckedBoundsResultTag), name.result, futureSystemOps.createProm[T](uncheckedBoundsResultTag).tree)
         val execContextValDef = ValDef(NoMods, name.execContext, TypeTree(), execContext)
 
         val apply0DefDef: DefDef = {
@@ -43,7 +43,7 @@ trait AsyncTransform {
           // See SI-1247 for the the optimization that avoids creation.
           DefDef(NoMods, name.apply, Nil, Nil, TypeTree(definitions.UnitTpe), Apply(Ident(name.apply), literalNull :: Nil))
         }
-        List(emptyConstructor, stateVar, result, execContextValDef) ++ List(applyDefDefDummyBody, apply0DefDef)
+        List(emptyConstructor, stateVar) ++ resultAndAccessors ++ List(execContextValDef) ++ List(applyDefDefDummyBody, apply0DefDef)
       }
 
       val tryToUnit = appliedType(definitions.FunctionClass(1), futureSystemOps.tryType[Any], typeOf[Unit])

--- a/src/main/scala/scala/async/internal/Lifter.scala
+++ b/src/main/scala/scala/async/internal/Lifter.scala
@@ -40,6 +40,7 @@ trait Lifter {
     val defs: Map[Tree, Int] = {
       /** Collect the DefTrees directly enclosed within `t` that have the same owner */
       def collectDirectlyEnclosedDefs(t: Tree): List[DefTree] = t match {
+        case ld: LabelDef => Nil
         case dt: DefTree => dt :: Nil
         case _: Function => Nil
         case t           =>

--- a/src/main/scala/scala/async/internal/StateAssigner.scala
+++ b/src/main/scala/scala/async/internal/StateAssigner.scala
@@ -7,8 +7,7 @@ package scala.async.internal
 private[async] final class StateAssigner {
   private var current = StateAssigner.Initial
 
-  def nextState(): Int =
-    try current finally current += 1
+  def nextState(): Int = try current finally current += 1
 }
 
 object StateAssigner {

--- a/src/test/scala/scala/async/TreeInterrogation.scala
+++ b/src/test/scala/scala/async/TreeInterrogation.scala
@@ -82,6 +82,8 @@ object TreeInterrogation extends App {
     println(tree)
     val tree1 = tb.typeCheck(tree.duplicate)
     println(cm.universe.show(tree1))
+
     println(tb.eval(tree))
   }
+
 }

--- a/src/test/scala/scala/async/run/late/LateExpansion.scala
+++ b/src/test/scala/scala/async/run/late/LateExpansion.scala
@@ -1,0 +1,170 @@
+package scala.async.run.late
+
+import java.io.File
+
+import junit.framework.Assert.assertEquals
+import org.junit.Test
+
+import scala.annotation.StaticAnnotation
+import scala.async.internal.{AsyncId, AsyncMacro}
+import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
+import scala.tools.nsc._
+import scala.tools.nsc.plugins.{Plugin, PluginComponent}
+import scala.tools.nsc.reporters.StoreReporter
+import scala.tools.nsc.transform.TypingTransformers
+
+// Tests for customized use of the async transform from a compiler plugin, which
+// calls it from a new phase that runs after patmat.
+class LateExpansion {
+  @Test def test0(): Unit = {
+    val result = wrapAndRun(
+      """
+        | @autoawait def id(a: String) = a
+        | id("foo") + id("bar")
+        | """.stripMargin)
+    assertEquals("foobar", result)
+  }
+  @Test def testGuard(): Unit = {
+    val result = wrapAndRun(
+      """
+        | @autoawait def id[A](a: A) = a
+        | "" match { case _ if id(false) => ???; case _ => "okay" }
+        | """.stripMargin)
+    assertEquals("okay", result)
+  }
+
+  @Test def testExtractor(): Unit = {
+    val result = wrapAndRun(
+      """
+        | object Extractor { @autoawait def unapply(a: String) = Some((a, a)) }
+        | "" match { case Extractor(a, b) if "".isEmpty => a == b }
+        | """.stripMargin)
+    assertEquals(true, result)
+  }
+
+  @Test def testNestedMatchExtractor(): Unit = {
+    val result = wrapAndRun(
+      """
+        | object Extractor { @autoawait def unapply(a: String) = Some((a, a)) }
+        | "" match {
+        |   case _ if "".isEmpty =>
+        |     "" match { case Extractor(a, b) => a == b }
+        | }
+        | """.stripMargin)
+    assertEquals(true, result)
+  }
+
+  @Test def testCombo(): Unit = {
+    val result = wrapAndRun(
+      """
+        | object Extractor1 { @autoawait def unapply(a: String) = Some((a + 1, a + 2)) }
+        | object Extractor2 { @autoawait def unapply(a: String) = Some(a + 3) }
+        | @autoawait def id(a: String) = a
+        | println("Test.test")
+        | val r1 = Predef.identity("blerg") match {
+        |   case x if " ".isEmpty => "case 2: " + x
+        |   case Extractor1(Extractor2(x), y: String) if x == "xxx" => "case 1: " + x + ":" + y
+        |     x match {
+        |       case Extractor1(Extractor2(x), y: String) =>
+        |       case _ =>
+        |     }
+        |   case Extractor2(x) => "case 3: " + x
+        | }
+        | r1
+        | """.stripMargin)
+    assertEquals("case 3: blerg3", result)
+  }
+
+  def wrapAndRun(code: String): Any = {
+    run(
+      s"""
+         |import scala.async.run.late.{autoawait,lateasync}
+         |object Test {
+         |  @lateasync
+         |  def test: Any = {
+         |    $code
+         |  }
+         |}
+         | """.stripMargin)
+  }
+
+  def run(code: String): Any = {
+    val reporter = new StoreReporter
+    val settings = new Settings(println(_))
+    settings.outdir.value = sys.props("java.io.tmpdir")
+    settings.embeddedDefaults(getClass.getClassLoader)
+    val isInSBT = !settings.classpath.isSetByUser
+    if (isInSBT) settings.usejavacp.value = true
+    val global = new Global(settings, reporter) {
+      self =>
+
+      object late extends {
+        val global: self.type = self
+      } with LatePlugin
+
+      override protected def loadPlugins(): List[Plugin] = late :: Nil
+    }
+    import global._
+
+    val run = new Run
+    val source = newSourceFile(code)
+    run.compileSources(source :: Nil)
+    assert(!reporter.hasErrors, reporter.infos.mkString("\n"))
+    val loader = new URLClassLoader(Seq(new File(settings.outdir.value).toURI.toURL), global.getClass.getClassLoader)
+    val cls = loader.loadClass("Test")
+    cls.getMethod("test").invoke(null)
+  }
+}
+
+abstract class LatePlugin extends Plugin {
+  import global._
+
+  override val components: List[PluginComponent] = List(new PluginComponent with TypingTransformers {
+    val global: LatePlugin.this.global.type = LatePlugin.this.global
+
+    lazy val asyncIdSym = symbolOf[AsyncId.type]
+    lazy val asyncSym = asyncIdSym.info.member(TermName("async"))
+    lazy val awaitSym = asyncIdSym.info.member(TermName("await"))
+    lazy val autoAwaitSym = symbolOf[autoawait]
+    lazy val lateAsyncSym = symbolOf[lateasync]
+
+    def newTransformer(unit: CompilationUnit) = new TypingTransformer(unit) {
+      override def transform(tree: Tree): Tree = {
+        super.transform(tree) match {
+          case ap@Apply(fun, args) if fun.symbol.hasAnnotation(autoAwaitSym) =>
+            localTyper.typed(Apply(TypeApply(gen.mkAttributedRef(asyncIdSym.typeOfThis, awaitSym), TypeTree(ap.tpe) :: Nil), ap :: Nil))
+          case dd: DefDef if dd.symbol.hasAnnotation(lateAsyncSym) => atOwner(dd.symbol) {
+            val expandee = localTyper.context.withMacrosDisabled(
+              localTyper.typed(Apply(TypeApply(gen.mkAttributedRef(asyncIdSym.typeOfThis, asyncSym), TypeTree(dd.rhs.tpe) :: Nil), List(dd.rhs)))
+            )
+            val c = analyzer.macroContext(localTyper, gen.mkAttributedRef(asyncIdSym), expandee)
+            val asyncMacro = AsyncMacro(c, AsyncId)(dd.rhs)
+            val code = asyncMacro.asyncTransform[Any](localTyper.typed(Literal(Constant(()))))(c.weakTypeTag[Any])
+            deriveDefDef(dd)(_ => localTyper.typed(code))
+          }
+          case x => x
+        }
+      }
+    }
+
+    override def newPhase(prev: Phase): Phase = new StdPhase(prev) {
+      override def apply(unit: CompilationUnit): Unit = {
+        val translated = newTransformer(unit).transformUnit(unit)
+        //println(show(unit.body))
+        translated
+      }
+    }
+
+    override val runsAfter: List[String] = "patmat" :: Nil
+    override val phaseName: String = "postpatmat"
+
+  })
+  override val description: String = "postpatmat"
+  override val name: String = "postpatmat"
+}
+
+// Methods with this annotation are translated to having the RHS wrapped in `AsyncId.async { <original RHS> }`
+final class lateasync extends StaticAnnotation
+
+// Calls to methods with this annotation are translated to `AsyncId.await(<call>)`
+final class autoawait extends StaticAnnotation


### PR DESCRIPTION
Currently, the async transformation is performed during the typer
phase, like all other macros.

We have to levy a few artificial restrictions on whern an async
boundary may be: for instance we don't support await within a
pattern guard. A more natural home for the transform would be
after patterns have been translated.

The test case in this commit shows how to use the async transform
from a custom compiler phase after patmat.

The remainder of the commit updates the implementation to handle
the new tree shapes.

For states that correspond to a label definition, we use `-symbol.id`
as the state ID. This made it easier to emit the forward jumps to when
processing the label application before we had seen the label
definition.

I've also made the transformation more efficient in the way it checks
whether a given tree encloses an `await` call: we traverse the input
tree at the start of the macro, and decorate it with tree attachments
containig the answer to this question. Even after the ANF and state
machine transforms introduce new layers of synthetic trees, the
`containsAwait` code need only traverse shallowly through those
trees to find a child that has the cached answer from the original
traversal.

I had to special case the ANF transform for expressions that always
lead to a label jump: we avoids trying to push an assignment to a result
variable into `if (cond) jump1() else jump2()`, in trees of the form:

```
% cat sandbox/jump.scala
class Test {
  def test = {
    (null: Any) match {
      case _: String => ""
      case _ => ""
    }
  }
}

% qscalac -Xprint:patmat -Xprint-types sandbox/jump.scala
    def test: String = {
      case <synthetic> val x1: Any = (null{Null(null)}: Any){Any};
      case5(){
        if (x1.isInstanceOf{[T0]=> Boolean}[String]{Boolean})
          matchEnd4{(x: String)String}(""{String("")}){String}
        else
          case6{()String}(){String}{String}
      }{String};
      case6(){
        matchEnd4{(x: String)String}(""{String("")}){String}
      }{String};
      matchEnd4(x: String){
        x{String}
      }{String}
    }{String}
```