### PR TITLE
Rework extension point for checking for already-completed futures

### DIFF
--- a/src/main/scala/scala/async/internal/TransformUtils.scala
+++ b/src/main/scala/scala/async/internal/TransformUtils.scala
@@ -24,6 +24,7 @@ private[async] trait TransformUtils {
     val ifRes         = "ifres"
     val await         = "await"
     val bindSuffix    = "$bind"
+    val completed     = newTermName("completed")
 
     val state         = newTermName("state")
     val result        = newTermName("result")


### PR DESCRIPTION
The current extension point assumes that if a future is in the
completed state, a subsequent call to get the already completed
value will succeed. While this assumption holds for
scala.concurrent.Future, it might not hold for a future system
that has semantics like a weak reference.

This commit uses a single call `getCompleted` to query the state
and get the already completed value. This returns null if the
value is not available.