### PR TITLE
In tests use tmp dir working on all operating systems

### DIFF
--- a/src/test/scala/scala/async/run/late/LateExpansion.scala
+++ b/src/test/scala/scala/async/run/late/LateExpansion.scala
@@ -390,7 +390,7 @@ class LateExpansion {
     val reporter = new StoreReporter
     val settings = new Settings(println(_))
     // settings.processArgumentString("-Xprint:patmat,postpatmat,jvm -Ybackend:GenASM -nowarn")
-    settings.outdir.value = "/tmp"
+    settings.outdir.value = sys.props("java.io.tmpdir")
     settings.embeddedDefaults(getClass.getClassLoader)
     val isInSBT = !settings.classpath.isSetByUser
     if (isInSBT) settings.usejavacp.value = true


### PR DESCRIPTION
After this change tests pass also on Windows.

It turns out in the past there was used `sys.props("java.io.tmpdir")` but it was changed during https://github.com/mpociecha/async/commit/549a656fa22af5f7f0c5e89dd6e0a19ed4b604f5. I'm not sure what was the reason.