### PR TITLE
Reduce logging overhead and minor cleanups

### DIFF
--- a/src/main/scala/scala/async/internal/AnfTransform.scala
+++ b/src/main/scala/scala/async/internal/AnfTransform.scala
@@ -38,9 +38,11 @@ private[async] trait AnfTransform {
         indent += 1
         def oneLine(s: Any) = s.toString.replaceAll("""\n""", "\\\\n").take(127)
         try {
-          AsyncUtils.trace(s"${indentString}$prefix(${oneLine(args)})")
+          if(AsyncUtils.trace)
+            AsyncUtils.trace(s"$indentString$prefix(${oneLine(args)})")
           val result = t
-          AsyncUtils.trace(s"${indentString}= ${oneLine(result)}")
+          if(AsyncUtils.trace)
+            AsyncUtils.trace(s"$indentString= ${oneLine(result)}")
           result
         } finally {
           indent -= 1

--- a/src/main/scala/scala/async/internal/AsyncAnalysis.scala
+++ b/src/main/scala/scala/async/internal/AsyncAnalysis.scala
@@ -5,8 +5,6 @@
 package scala.async.internal
 
 import scala.collection.mutable.ListBuffer
-import scala.reflect.macros.Context
-import scala.collection.mutable
 
 trait AsyncAnalysis {
   self: AsyncMacro =>
@@ -30,7 +28,7 @@ trait AsyncAnalysis {
 
     override def nestedClass(classDef: ClassDef) {
       val kind = if (classDef.symbol.asClass.isTrait) "trait" else "class"
-      reportUnsupportedAwait(classDef, s"nested ${kind}")
+      reportUnsupportedAwait(classDef, s"nested $kind")
     }
 
     override def nestedModule(module: ModuleDef) {

--- a/src/main/scala/scala/async/internal/AsyncBase.scala
+++ b/src/main/scala/scala/async/internal/AsyncBase.scala
@@ -46,7 +46,7 @@ abstract class AsyncBase {
     val asyncMacro = AsyncMacro(c, self)(body.tree)
 
     val code = asyncMacro.asyncTransform[T](execContext.tree)(c.weakTypeTag[T])
-    AsyncUtils.vprintln(s"async state machine transform expands to:\n ${code}")
+    AsyncUtils.vprintln(s"async state machine transform expands to:\n $code")
 
     // Mark range positions for synthetic code as transparent to allow some wiggle room for overlapping ranges
     for (t <- code) t.setPos(t.pos.makeTransparent)

--- a/src/main/scala/scala/async/internal/AsyncId.scala
+++ b/src/main/scala/scala/async/internal/AsyncId.scala
@@ -25,10 +25,10 @@ object AsyncTestLV extends AsyncBase {
 
   def asyncIdImpl[T: c.WeakTypeTag](c: Context)(body: c.Expr[T]): c.Expr[T] = asyncImpl[T](c)(body)(c.literalUnit)
 
-  var log: List[(String, Any)] = List()
+  var log: List[(String, Any)] = Nil
   def assertNulledOut(a: Any): Unit = assert(log.exists(_._2 == a), AsyncTestLV.log)
   def assertNotNulledOut(a: Any): Unit = assert(!log.exists(_._2 == a), AsyncTestLV.log)
-  def clear() = log = Nil
+  def clear(): Unit = log = Nil
 
   def apply(name: String, v: Any): Unit =
     log ::= (name -> v)

--- a/src/main/scala/scala/async/internal/AsyncMacro.scala
+++ b/src/main/scala/scala/async/internal/AsyncMacro.scala
@@ -24,7 +24,7 @@ private[async] trait AsyncMacro
   val body: c.Tree
   var containsAwait: c.Tree => Boolean
 
-  lazy val macroPos = c.macroApplication.pos.makeTransparent
-  def atMacroPos(t: c.Tree) = c.universe.atPos(macroPos)(t)
+  lazy val macroPos: c.universe.Position = c.macroApplication.pos.makeTransparent
+  def atMacroPos(t: c.Tree): c.Tree = c.universe.atPos(macroPos)(t)
 
 }

--- a/src/main/scala/scala/async/internal/AsyncTransform.scala
+++ b/src/main/scala/scala/async/internal/AsyncTransform.scala
@@ -66,11 +66,12 @@ trait AsyncTransform {
 
     val stateMachineClass = stateMachine.symbol
     val asyncBlock: AsyncBlock = {
-      val symLookup = new SymLookup(stateMachineClass, applyDefDefDummyBody.vparamss.head.head.symbol)
+      val symLookup = SymLookup(stateMachineClass, applyDefDefDummyBody.vparamss.head.head.symbol)
       buildAsyncBlock(anfTree, symLookup)
     }
 
-    logDiagnostics(anfTree, asyncBlock.asyncStates.map(_.toString))
+    if(AsyncUtils.verbose)
+      logDiagnostics(anfTree, asyncBlock.asyncStates.map(_.toString))
 
     val liftedFields: List[Tree] = liftables(asyncBlock.asyncStates)
 

--- a/src/main/scala/scala/async/internal/AsyncUtils.scala
+++ b/src/main/scala/scala/async/internal/AsyncUtils.scala
@@ -5,12 +5,13 @@ package scala.async.internal
 
 object AsyncUtils {
 
+
   private def enabled(level: String) = sys.props.getOrElse(s"scala.async.$level", "false").equalsIgnoreCase("true")
 
-  private def verbose = enabled("debug")
-  private def trace   = enabled("trace")
+  private[async] val verbose = enabled("debug")
+  private[async] val trace   = enabled("trace")
 
-  private[async] def vprintln(s: => Any): Unit = if (verbose) println(s"[async] $s")
+  @inline private[async] def vprintln(s: => Any): Unit = if (verbose) println(s"[async] $s")
 
-  private[async] def trace(s: => Any): Unit = if (trace) println(s"[async] $s")
+  @inline private[async] def trace(s: => Any): Unit = if (trace) println(s"[async] $s")
 }

--- a/src/main/scala/scala/async/internal/ExprBuilder.scala
+++ b/src/main/scala/scala/async/internal/ExprBuilder.scala
@@ -4,10 +4,7 @@
 package scala.async.internal
 
 import scala.collection.mutable.ListBuffer
-import collection.mutable
 import language.existentials
-import scala.reflect.api.Universe
-import scala.reflect.api
 
 trait ExprBuilder {
   builder: AsyncMacro =>
@@ -370,11 +367,11 @@ trait ExprBuilder {
             c.Expr[futureSystem.Prom[T]](symLookup.memberRef(name.result)), lastStateBody)
           mkHandlerCase(lastState.state, Block(rhs.tree, Return(literalUnit)))
         }
-        asyncStates.toList match {
+        asyncStates match {
           case s :: Nil =>
             List(caseForLastState)
           case _        =>
-            val initCases = for (state <- asyncStates.toList.init) yield state.mkHandlerCaseForState[T]
+            val initCases = for (state <- asyncStates.init) yield state.mkHandlerCaseForState[T]
             initCases :+ caseForLastState
         }
       }
@@ -442,7 +439,7 @@ trait ExprBuilder {
        *     }
        */
       def onCompleteHandler[T: WeakTypeTag]: Tree = {
-        val onCompletes = initStates.flatMap(_.mkOnCompleteHandler[T]).toList
+        val onCompletes = initStates.flatMap(_.mkOnCompleteHandler[T])
         forever {
           adaptToUnit(toList(resumeFunTree))
         }

--- a/src/test/scala/scala/async/TreeInterrogation.scala
+++ b/src/test/scala/scala/async/TreeInterrogation.scala
@@ -13,7 +13,7 @@ class TreeInterrogation {
   @Test
   def `a minimal set of vals are lifted to vars`() {
     val cm = reflect.runtime.currentMirror
-    val tb = mkToolbox(s"-cp ${toolboxClasspath}")
+    val tb = mkToolbox(s"-cp $toolboxClasspath")
     val tree = tb.parse(
       """| import _root_.scala.async.internal.AsyncId._
         | async {
@@ -49,7 +49,7 @@ class TreeInterrogation {
               && !dd.symbol.asTerm.isAccessor && !dd.symbol.asTerm.isSetter => dd.name
         }
     }.flatten
-    defDefs.map(_.decoded.trim).toList mustStartWith (List("foo$macro$", "<init>", "apply", "apply"))
+    defDefs.map(_.decoded.trim) mustStartWith List("foo$macro$", "<init>", "apply", "apply")
   }
 }
 

--- a/src/test/scala/scala/async/run/SyncOptimizationSpec.scala
+++ b/src/test/scala/scala/async/run/SyncOptimizationSpec.scala
@@ -10,7 +10,7 @@ class SyncOptimizationSpec {
   @Test
   def awaitOnCompletedFutureRunsOnSameThread: Unit = {
 
-    def stackDepth = Thread.currentThread().getStackTrace.size
+    def stackDepth = Thread.currentThread().getStackTrace.length
 
     val future = async {
       val thread1 = Thread.currentThread

--- a/src/test/scala/scala/async/run/anf/AnfTransformSpec.scala
+++ b/src/test/scala/scala/async/run/anf/AnfTransformSpec.scala
@@ -217,7 +217,7 @@ class AnfTransformSpec {
     val result = async {
       var i = 0
       def next() = {
-        i += 1;
+        i += 1
         i
       }
       foo(next(), await(next()))
@@ -298,7 +298,7 @@ class AnfTransformSpec {
     val result = async {
       var i = 0
       def next() = {
-        i += 1;
+        i += 1
         i
       }
       foo(b = next(), a = await(next()))
@@ -311,7 +311,7 @@ class AnfTransformSpec {
     import AsyncId.{async, await}
     var i = 0
     def next() = {
-      i += 1;
+      i += 1
       i
     }
     def foo(a: Int = next(), b: Int = next()) = (a, b)

--- a/src/test/scala/scala/async/run/ifelse4/IfElse4.scala
+++ b/src/test/scala/scala/async/run/ifelse4/IfElse4.scala
@@ -56,7 +56,7 @@ class IfElse4Spec {
   @Test
   def `await result with complex type containing skolem`() {
     val o = new TestIfElse4Class
-    val fut = o.run(new o.K(null))
+    val fut = o.run(o.K(null))
     val res = Await.result(fut, 2 seconds)
     res.id mustBe ("foo")
   }

--- a/src/test/scala/scala/async/run/match0/Match0.scala
+++ b/src/test/scala/scala/async/run/match0/Match0.scala
@@ -73,7 +73,7 @@ class MatchSpec {
       val x = 1
       Option(x) match {
         case op @ Some(x) =>
-          assert(op == Some(1))
+          assert(op.contains(1))
           x + AsyncId.await(x)
         case None => AsyncId.await(0)
       }


### PR DESCRIPTION
The logging even when disabled was doing (the default case) was doing a significant amount of work (esp the ```logDiagnostics``` parametersl).

Also ```AsyncUtils.verbose``` and ```AsyncUtils.debug``` were computed on every call.

The result of the changes are minor cleanups seen along the way.
